### PR TITLE
setup-node doesn't yet support node22, so use node20

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ jobs:
     - name: setup node
       uses: actions/setup-node@v4
       with:
-        node-version: '22'
+        node-version: '20'
     - name: install deps
       run: |
         # install app deps

--- a/action.yml
+++ b/action.yml
@@ -16,5 +16,5 @@ inputs:
     required: false
     default: true
 runs:
-  using: "node22"
+  using: "node20"
   main: "dist/index.js"


### PR DESCRIPTION
This reverts #1, and fixes
https://github.com/jaymzh/main-branch-check-action/commit/db55d6c822cf04fbbf086420d8af7b76173c86e0
which moved to 20, but incompletely.

Signed-off-by: Phil Dibowitz <phil@ipom.com>
