### PR TITLE
Some fix-ups

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,8 +20,6 @@ jobs:
       run: |
         # install app deps
         npm install
-        # install build deps
-        npm install -g @vercel/ncc
     - name: build
       run: |
         rm dist/index.js

--- a/action.yml
+++ b/action.yml
@@ -18,3 +18,6 @@ inputs:
 runs:
   using: "node20"
   main: "dist/index.js"
+branding:
+  icon: "git-branch"
+  color: "gray-dark"


### PR DESCRIPTION
* Now that ncc is in devDependencies, we shouldn't need the global
  install in CI
* Add branding bits to the actions.yaml

Signed-off-by: Phil Dibowitz <phil@ipom.com>
