### PR TITLE
Externalize Actions deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,5 @@
 dist/index.js: index.js
-	./node_modules/.bin/ncc build index.js -o dist
+	# we externalize the Actions toolkit deps because otherwise
+	# ncc chokes on their imports
+	./node_modules/.bin/ncc build index.js -o dist \
+		-e @actions/github -e @actions/core


### PR DESCRIPTION
Otherwise newer github libs will cause ncc to choke.

Signed-off-by: Phil Dibowitz <phil@ipom.com>
